### PR TITLE
Add landing page for escape room tokens

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Escape Room - Inicio</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2rem; }
+        form { margin-top: 1rem; }
+        label { display: block; margin-bottom: .5rem; }
+        input { margin-bottom: 1rem; }
+        #resultado { margin-top: 1rem; font-weight: bold; }
+    </style>
+</head>
+<body>
+    <h1>Escape Room: Monosala Legacy</h1>
+    <p>Bienvenido al juego de escape. Resuelve los puzzles, descubre las palabras clave y
+       introdúcelas a continuación para abrir la puerta de salida.</p>
+
+    <form id="escape-form">
+        <label>Token 1: <input type="text" id="token1" required></label>
+        <label>Token 2: <input type="text" id="token2" required></label>
+        <label>Token 3: <input type="text" id="token3" required></label>
+        <label>Token 4: <input type="text" id="token4" required></label>
+        <button type="submit">Intentar salir</button>
+    </form>
+
+    <div id="resultado"></div>
+
+    <script>
+        const expected = ["VERTX", "KAFKA", "REDIS", "JAVA21"];
+        document.getElementById('escape-form').addEventListener('submit', function(e) {
+            e.preventDefault();
+            const provided = [
+                document.getElementById('token1').value.trim().toUpperCase(),
+                document.getElementById('token2').value.trim().toUpperCase(),
+                document.getElementById('token3').value.trim().toUpperCase(),
+                document.getElementById('token4').value.trim().toUpperCase()
+            ];
+            const resultEl = document.getElementById('resultado');
+            if (expected.every((val, idx) => val === provided[idx])) {
+                resultEl.textContent = '🎉 ¡Has salido del escape room!';
+                resultEl.style.color = 'green';
+            } else {
+                resultEl.textContent = 'Código incorrecto, sigue intentando.';
+                resultEl.style.color = 'red';
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add introductory web page describing the game
- include form to enter tokens and check against expected sequence

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ada73192c483238597c707219131da