### PR TITLE
Add multi-page puzzle flow with navigation and result pages

### DIFF
--- a/bienvenida.html
+++ b/bienvenida.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Bienvenida</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Poppins', sans-serif;
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%);
+            color: #333;
+        }
+        #app {
+            background: #fff;
+            padding: 2rem;
+            border-radius: 1rem;
+            box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+            max-width: 400px;
+            width: 100%;
+            text-align: center;
+        }
+        h1 {
+            color: #ff6f61;
+        }
+        button {
+            margin-top: 1rem;
+            padding: .75rem 1rem;
+            background: linear-gradient(315deg, #6a11cb 0%, #2575fc 100%);
+            color: #fff;
+            border: none;
+            border-radius: .5rem;
+            cursor: pointer;
+            transition: background .3s ease;
+        }
+        button:hover {
+            background: linear-gradient(315deg, #2575fc 0%, #6a11cb 100%);
+        }
+    </style>
+</head>
+<body>
+<div id="app">
+    <h1>Escape Room</h1>
+    <p>Bienvenido al juego. Resuelve los cuatro puzzles para obtener los tokens y escapar.</p>
+    <button onclick="location.href='puzzle1.html'">Siguiente</button>
+</div>
+</body>
+</html>

--- a/enhorabuena.html
+++ b/enhorabuena.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>¡Enhorabuena!</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Poppins', sans-serif;
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%);
+            color: #333;
+        }
+        #app {
+            background: #fff;
+            padding: 2rem;
+            border-radius: 1rem;
+            box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+            max-width: 400px;
+            width: 100%;
+            text-align: center;
+        }
+        h1 {
+            color: #ff6f61;
+        }
+        button {
+            margin-top: 1rem;
+            padding: .75rem 1rem;
+            background: linear-gradient(315deg, #6a11cb 0%, #2575fc 100%);
+            color: #fff;
+            border: none;
+            border-radius: .5rem;
+            cursor: pointer;
+            transition: background .3s ease;
+        }
+        button:hover {
+            background: linear-gradient(315deg, #2575fc 0%, #6a11cb 100%);
+        }
+    </style>
+</head>
+<body>
+<div id="app">
+    <h1>🎉 ¡Enhorabuena!</h1>
+    <p>Has resuelto el escape room.</p>
+    <button onclick="location.href='bienvenida.html'">Volver al inicio</button>
+</div>
+</body>
+</html>

--- a/fallo.html
+++ b/fallo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Oooohh...</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Poppins', sans-serif;
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%);
+            color: #333;
+        }
+        #app {
+            background: #fff;
+            padding: 2rem;
+            border-radius: 1rem;
+            box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+            max-width: 400px;
+            width: 100%;
+            text-align: center;
+        }
+        h1 {
+            color: #ff6f61;
+        }
+        button {
+            margin-top: 1rem;
+            padding: .75rem 1rem;
+            background: linear-gradient(315deg, #6a11cb 0%, #2575fc 100%);
+            color: #fff;
+            border: none;
+            border-radius: .5rem;
+            cursor: pointer;
+            transition: background .3s ease;
+        }
+        button:hover {
+            background: linear-gradient(315deg, #2575fc 0%, #6a11cb 100%);
+        }
+    </style>
+</head>
+<body>
+<div id="app">
+    <h1>Oooohh...</h1>
+    <p>Los tokens no son correctos. ¡Inténtalo de nuevo!</p>
+    <button onclick="location.href='index.html'">Volver</button>
+</div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -54,11 +54,6 @@
         button:hover {
             background: linear-gradient(315deg, #2575fc 0%, #6a11cb 100%);
         }
-        #resultado {
-            margin-top: 1rem;
-            font-weight: 700;
-            text-align: center;
-        }
     </style>
 </head>
 <body>
@@ -75,7 +70,6 @@
         <button type="submit">Intentar salir</button>
     </form>
 
-    <div id="resultado" :style="{ color: color }">{{ mensaje }}</div>
 </div>
 
     <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
@@ -87,9 +81,7 @@
                     token1: '',
                     token2: '',
                     token3: '',
-                    token4: '',
-                    mensaje: '',
-                    color: ''
+                    token4: ''
                 };
             },
             methods: {
@@ -103,11 +95,9 @@
                     const res = await fetch('/check?' + params.toString());
                     const data = await res.json();
                     if (data.success) {
-                        this.mensaje = '🎉 ¡Has salido del escape room!';
-                        this.color = 'green';
+                        window.location.href = 'enhorabuena.html';
                     } else {
-                        this.mensaje = 'Código incorrecto, sigue intentando.';
-                        this.color = 'red';
+                        window.location.href = 'fallo.html';
                     }
                 }
             }

--- a/puzzle1.html
+++ b/puzzle1.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Puzzle 1</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Poppins', sans-serif;
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%);
+            color: #333;
+        }
+        #app {
+            background: #fff;
+            padding: 2rem;
+            border-radius: 1rem;
+            box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+            max-width: 400px;
+            width: 100%;
+            text-align: center;
+        }
+        h1 {
+            color: #ff6f61;
+        }
+        button {
+            margin-top: 1rem;
+            padding: .75rem 1rem;
+            background: linear-gradient(315deg, #6a11cb 0%, #2575fc 100%);
+            color: #fff;
+            border: none;
+            border-radius: .5rem;
+            cursor: pointer;
+            transition: background .3s ease;
+        }
+        button:hover {
+            background: linear-gradient(315deg, #2575fc 0%, #6a11cb 100%);
+        }
+    </style>
+</head>
+<body>
+<div id="app">
+    <h1>Puzzle 1</h1>
+    <p>Aquí se presentará el primer puzzle.</p>
+    <button onclick="location.href='puzzle2.html'">Siguiente</button>
+</div>
+</body>
+</html>

--- a/puzzle2.html
+++ b/puzzle2.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Puzzle 2</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Poppins', sans-serif;
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%);
+            color: #333;
+        }
+        #app {
+            background: #fff;
+            padding: 2rem;
+            border-radius: 1rem;
+            box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+            max-width: 400px;
+            width: 100%;
+            text-align: center;
+        }
+        h1 {
+            color: #ff6f61;
+        }
+        .buttons {
+            margin-top: 1rem;
+            display: flex;
+            justify-content: space-between;
+        }
+        button {
+            padding: .75rem 1rem;
+            background: linear-gradient(315deg, #6a11cb 0%, #2575fc 100%);
+            color: #fff;
+            border: none;
+            border-radius: .5rem;
+            cursor: pointer;
+            transition: background .3s ease;
+        }
+        button:hover {
+            background: linear-gradient(315deg, #2575fc 0%, #6a11cb 100%);
+        }
+    </style>
+</head>
+<body>
+<div id="app">
+    <h1>Puzzle 2</h1>
+    <p>Descripción del segundo puzzle.</p>
+    <div class="buttons">
+        <button onclick="location.href='puzzle1.html'">Anterior</button>
+        <button onclick="location.href='puzzle3.html'">Siguiente</button>
+    </div>
+</div>
+</body>
+</html>

--- a/puzzle3.html
+++ b/puzzle3.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Puzzle 3</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Poppins', sans-serif;
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%);
+            color: #333;
+        }
+        #app {
+            background: #fff;
+            padding: 2rem;
+            border-radius: 1rem;
+            box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+            max-width: 400px;
+            width: 100%;
+            text-align: center;
+        }
+        h1 {
+            color: #ff6f61;
+        }
+        .buttons {
+            margin-top: 1rem;
+            display: flex;
+            justify-content: space-between;
+        }
+        button {
+            padding: .75rem 1rem;
+            background: linear-gradient(315deg, #6a11cb 0%, #2575fc 100%);
+            color: #fff;
+            border: none;
+            border-radius: .5rem;
+            cursor: pointer;
+            transition: background .3s ease;
+        }
+        button:hover {
+            background: linear-gradient(315deg, #2575fc 0%, #6a11cb 100%);
+        }
+    </style>
+</head>
+<body>
+<div id="app">
+    <h1>Puzzle 3</h1>
+    <p>Descripción del tercer puzzle.</p>
+    <div class="buttons">
+        <button onclick="location.href='puzzle2.html'">Anterior</button>
+        <button onclick="location.href='puzzle4.html'">Siguiente</button>
+    </div>
+</div>
+</body>
+</html>

--- a/puzzle4.html
+++ b/puzzle4.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Puzzle 4</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Poppins', sans-serif;
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%);
+            color: #333;
+        }
+        #app {
+            background: #fff;
+            padding: 2rem;
+            border-radius: 1rem;
+            box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+            max-width: 400px;
+            width: 100%;
+            text-align: center;
+        }
+        h1 {
+            color: #ff6f61;
+        }
+        .buttons {
+            margin-top: 1rem;
+            display: flex;
+            justify-content: space-between;
+        }
+        button {
+            padding: .75rem 1rem;
+            background: linear-gradient(315deg, #6a11cb 0%, #2575fc 100%);
+            color: #fff;
+            border: none;
+            border-radius: .5rem;
+            cursor: pointer;
+            transition: background .3s ease;
+        }
+        button:hover {
+            background: linear-gradient(315deg, #2575fc 0%, #6a11cb 100%);
+        }
+    </style>
+</head>
+<body>
+<div id="app">
+    <h1>Puzzle 4</h1>
+    <p>Descripción del cuarto puzzle.</p>
+    <div class="buttons">
+        <button onclick="location.href='puzzle3.html'">Anterior</button>
+        <button onclick="location.href='index.html'">Siguiente</button>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/java/com/chapterescape/Main.java
+++ b/src/main/java/com/chapterescape/Main.java
@@ -19,12 +19,30 @@ public class Main {
     public static void main(String[] args) throws IOException {
         HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
 
+        Map<String, String> pages = Map.of(
+                "/", "bienvenida.html",
+                "/bienvenida.html", "bienvenida.html",
+                "/puzzle1.html", "puzzle1.html",
+                "/puzzle2.html", "puzzle2.html",
+                "/puzzle3.html", "puzzle3.html",
+                "/puzzle4.html", "puzzle4.html",
+                "/index.html", "index.html",
+                "/enhorabuena.html", "enhorabuena.html",
+                "/fallo.html", "fallo.html"
+        );
+
         server.createContext("/", exchange -> {
             if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
                 exchange.sendResponseHeaders(405, -1);
                 return;
             }
-            byte[] bytes = Files.readAllBytes(Path.of("index.html"));
+            String path = exchange.getRequestURI().getPath();
+            String file = pages.get(path);
+            if (file == null) {
+                exchange.sendResponseHeaders(404, -1);
+                return;
+            }
+            byte[] bytes = Files.readAllBytes(Path.of(file));
             exchange.getResponseHeaders().add("Content-Type", "text/html; charset=UTF-8");
             exchange.sendResponseHeaders(200, bytes.length);
             try (var os = exchange.getResponseBody()) {


### PR DESCRIPTION
## Summary
- Add welcome and four puzzle pages with navigation buttons
- Redirect token verification to success and failure pages
- Serve all pages through HTTP server routing

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adb079566883239588931fcf5a36d5