### PR TITLE
Show token form after puzzle four

### DIFF
--- a/fallo.html
+++ b/fallo.html
@@ -48,7 +48,7 @@
 <div id="app">
     <h1>Oooohh...</h1>
     <p>Los tokens no son correctos. ¡Inténtalo de nuevo!</p>
-    <button onclick="location.href='index.html'">Volver</button>
+    <button onclick="location.href='formulario.html'">Volver</button>
 </div>
 </body>
 </html>

--- a/formulario.html
+++ b/formulario.html
@@ -2,7 +2,7 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
-    <title>Escape Room - Inicio</title>
+    <title>Escape Room - Comprobación</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
@@ -59,8 +59,7 @@
 <body>
 <div id="app">
     <h1>Escape Room: Monosala Legacy</h1>
-    <p>Bienvenido al juego de escape. Resuelve los puzzles, descubre las palabras clave y
-       introdúcelas a continuación para abrir la puerta de salida.</p>
+    <p>Introduce los tokens obtenidos en cada puzzle para abrir la puerta de salida.</p>
 
     <form @submit.prevent="comprobar">
         <label>Token 1: <input type="text" v-model="token1" required></label>

--- a/puzzle4.html
+++ b/puzzle4.html
@@ -54,7 +54,7 @@
     <p>Descripción del cuarto puzzle.</p>
     <div class="buttons">
         <button onclick="location.href='puzzle3.html'">Anterior</button>
-        <button onclick="location.href='index.html'">Siguiente</button>
+        <button onclick="location.href='formulario.html'">Siguiente</button>
     </div>
 </div>
 </body>

--- a/src/main/java/com/chapterescape/Main.java
+++ b/src/main/java/com/chapterescape/Main.java
@@ -26,7 +26,7 @@ public class Main {
                 "/puzzle2.html", "puzzle2.html",
                 "/puzzle3.html", "puzzle3.html",
                 "/puzzle4.html", "puzzle4.html",
-                "/index.html", "index.html",
+                "/formulario.html", "formulario.html",
                 "/enhorabuena.html", "enhorabuena.html",
                 "/fallo.html", "fallo.html"
         );


### PR DESCRIPTION
## Summary
- Replace final index page with `formulario.html` token form
- Link puzzle 4 and error page to new token form
- Update server routing so welcome page is default and form page reachable

## Testing
- `mvn test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adb2be650c8323885766ce6c582711