### PR TITLE
feat: mostrar codigo de puzzles con formato destacado

### DIFF
--- a/puzzle1.html
+++ b/puzzle1.html
@@ -6,6 +6,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/atom-one-dark.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
     <style>
         body {
             font-family: 'Poppins', sans-serif;
@@ -22,12 +24,19 @@
             padding: 2rem;
             border-radius: 1rem;
             box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
-            max-width: 400px;
+            max-width: 800px;
             width: 100%;
             text-align: center;
         }
         h1 {
             color: #ff6f61;
+        }
+        pre {
+            text-align: left;
+            background: #282c34;
+            border-radius: .5rem;
+            padding: 1rem;
+            overflow-x: auto;
         }
         button {
             margin-top: 1rem;
@@ -48,7 +57,36 @@
 <div id="app">
     <h1>Puzzle 1</h1>
     <p>Aquí se presentará el primer puzzle.</p>
+    <pre><code class="language-java">package com.chapterescape;
+
+import java.util.List;
+
+/**
+ * Objetivo: imprimir VERTX
+ * Pista: el mensaje está escondido tomando letras en posiciones correctas.
+ * Bug: límites e incremento.
+ */
+public class Puzzle1_OffByOne {
+
+    public static void main(String[] args) {
+        String noisy = &quot;VxEeQZrtYTXr—noep—XR!@#T$%^&amp;*()&quot;;
+        int start = 0;
+        int step  = 2; // sospechoso
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = start; i &lt;= noisy.length(); i += step) { // BUG: &lt;=
+            char c = noisy.charAt(i); // puede petar al final
+            if (Character.isAlphabetic(c)) {
+                sb.append(c);
+            }
+        }
+        String token = sb.toString();
+        System.out.println(token); // Debe imprimir: VERTX tras arreglo
+    }
+}
+</code></pre>
     <button onclick="location.href='puzzle2.html'">Siguiente</button>
 </div>
+<script>hljs.highlightAll();</script>
 </body>
 </html>

--- a/puzzle2.html
+++ b/puzzle2.html
@@ -6,6 +6,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/atom-one-dark.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
     <style>
         body {
             font-family: 'Poppins', sans-serif;
@@ -22,7 +24,7 @@
             padding: 2rem;
             border-radius: 1rem;
             box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
-            max-width: 400px;
+            max-width: 800px;
             width: 100%;
             text-align: center;
         }
@@ -33,6 +35,13 @@
             margin-top: 1rem;
             display: flex;
             justify-content: space-between;
+        }
+        pre {
+            text-align: left;
+            background: #282c34;
+            border-radius: .5rem;
+            padding: 1rem;
+            overflow-x: auto;
         }
         button {
             padding: .75rem 1rem;
@@ -52,10 +61,70 @@
 <div id="app">
     <h1>Puzzle 2</h1>
     <p>Descripción del segundo puzzle.</p>
+    <pre><code class="language-java">package com.chapterescape;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Objetivo: evitar deadlock y conseguir que ambos hilos impriman y formen &quot;KAFKA&quot;.
+ * Bug: orden inconsistente de adquisición de locks.
+ */
+public class Puzzle2_Deadlock {
+    private static final Lock A = new ReentrantLock();
+    private static final Lock B = new ReentrantLock();
+
+    private static StringBuilder out = new StringBuilder();
+
+    public static void main(String[] args) throws InterruptedException {
+        Thread t1 = new Thread(() -&gt; {
+            A.lock();
+            try {
+                sleep(50);
+                B.lock();
+                try {
+                    out.append(&quot;KA&quot;);
+                } finally {
+                    B.unlock();
+                }
+            } finally {
+                A.unlock();
+            }
+        }, &quot;T1&quot;);
+
+        Thread t2 = new Thread(() -&gt; {
+            // BUG: orden inverso
+            B.lock();
+            try {
+                sleep(50);
+                A.lock();
+                try {
+                    out.append(&quot;FKA&quot;);
+                } finally {
+                    A.unlock();
+                }
+            } finally {
+                B.unlock();
+            }
+        }, &quot;T2&quot;);
+
+        t1.start(); t2.start();
+        t1.join(); t2.join();
+
+        var token = out.toString(); // debería ser exactamente &quot;KAFKA&quot;
+        System.out.println(token);
+    }
+
+    private static void sleep(long ms) {
+        try { Thread.sleep(ms); } catch (InterruptedException ignored) {}
+    }
+}
+</code></pre>
     <div class="buttons">
         <button onclick="location.href='puzzle1.html'">Anterior</button>
         <button onclick="location.href='puzzle3.html'">Siguiente</button>
     </div>
 </div>
+<script>hljs.highlightAll();</script>
 </body>
 </html>

--- a/puzzle3.html
+++ b/puzzle3.html
@@ -6,6 +6,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/atom-one-dark.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
     <style>
         body {
             font-family: 'Poppins', sans-serif;
@@ -22,7 +24,7 @@
             padding: 2rem;
             border-radius: 1rem;
             box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
-            max-width: 400px;
+            max-width: 800px;
             width: 100%;
             text-align: center;
         }
@@ -33,6 +35,13 @@
             margin-top: 1rem;
             display: flex;
             justify-content: space-between;
+        }
+        pre {
+            text-align: left;
+            background: #282c34;
+            border-radius: .5rem;
+            padding: 1rem;
+            overflow-x: auto;
         }
         button {
             padding: .75rem 1rem;
@@ -52,10 +61,51 @@
 <div id="app">
     <h1>Puzzle 3</h1>
     <p>Descripción del tercer puzzle.</p>
+    <pre><code class="language-java">package com.chapterescape;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Objetivo: de estas líneas sacar &quot;REDIS&quot; concatenando el contenido de [x] correcto en orden.
+ * Bug: regex demasiado codiciosa / grupos mal definidos.
+ */
+public class Puzzle3_RegexIntel {
+
+    public static void main(String[] args) {
+        var lines = List.of(
+                &quot;2025-08-21 INFO payload id=001 user=42 meta=[ignore] tag=[RE] extra=ok trail=[x]&quot;,
+                &quot;2025-08-21 INFO payload id=002 user=42 meta=[foo]    tag=[D]  extra=ok trail=[y]&quot;,
+                &quot;2025-08-21 INFO payload id=003 user=42 meta=[bar]    tag=[I]  extra=ok trail=[z]&quot;,
+                &quot;2025-08-21 INFO payload id=004 user=42 meta=[baz]    tag=[S]  extra=ok trail=[w]&quot;
+        );
+
+        // BUG: codiciosa y no anclada al campo &#x27;tag&#x27;
+        Pattern p = Pattern.compile(&quot;tag=(.*)&quot;);
+
+        StringBuilder sb = new StringBuilder();
+        for (String line : lines) {
+            Matcher m = p.matcher(line);
+            if (m.find()) {
+                var chunk = m.group(1);
+                // Lógica de ensamblado (correcta), pero falla si la captura es basura
+                if (chunk.length() &gt;= 2 &amp;&amp; chunk.startsWith(&quot;RE&quot;)) {
+                    sb.append(&quot;RE&quot;);
+                } else if (!chunk.isEmpty()) {
+                    sb.append(chunk.charAt(0));
+                }
+            }
+        }
+        System.out.println(sb.toString()); // Con el bug: basura. Arreglado: REDIS.
+    }
+}
+</code></pre>
     <div class="buttons">
         <button onclick="location.href='puzzle2.html'">Anterior</button>
         <button onclick="location.href='puzzle4.html'">Siguiente</button>
     </div>
 </div>
+<script>hljs.highlightAll();</script>
 </body>
 </html>

--- a/puzzle4.html
+++ b/puzzle4.html
@@ -6,6 +6,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/atom-one-dark.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
     <style>
         body {
             font-family: 'Poppins', sans-serif;
@@ -22,7 +24,7 @@
             padding: 2rem;
             border-radius: 1rem;
             box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
-            max-width: 400px;
+            max-width: 800px;
             width: 100%;
             text-align: center;
         }
@@ -33,6 +35,13 @@
             margin-top: 1rem;
             display: flex;
             justify-content: space-between;
+        }
+        pre {
+            text-align: left;
+            background: #282c34;
+            border-radius: .5rem;
+            padding: 1rem;
+            overflow-x: auto;
         }
         button {
             padding: .75rem 1rem;
@@ -52,10 +61,49 @@
 <div id="app">
     <h1>Puzzle 4</h1>
     <p>Descripción del cuarto puzzle.</p>
+    <pre><code class="language-java">package com.chapterescape;
+
+import java.nio.charset.Charset;
+import java.util.Base64;
+
+/**
+ * Objetivo: imprimir &quot;JAVA21&quot;.
+ * Proceso correcto: Base64 decode, luego shift -1 sobre letras/dígitos que corresponda.
+ * Bugs: charset y dirección del shift.
+ */
+public class Puzzle4_CryptoChain {
+
+    public static void main(String[] args) {
+        // Base64 de &quot;KBWB32&quot; =&gt; &quot;S0JXQjMy&quot;
+        String base64 = &quot;S0JXQjMy&quot;;
+        byte[] decoded = Base64.getDecoder().decode(base64);
+
+        // BUG: charset y shifts
+        String s = new String(decoded, Charset.forName(&quot;ISO-8859-1&quot;));
+        StringBuilder out = new StringBuilder();
+
+        for (char c : s.toCharArray()) {
+            if (Character.isUpperCase(c)) {
+                // incorrecto: +1
+                char shifted = (char) (&#x27;A&#x27; + (c - &#x27;A&#x27; + 1) % 26);
+                out.append(shifted);
+            } else if (Character.isDigit(c)) {
+                // incorrecto: +1
+                char shifted = (char) (&#x27;0&#x27; + (c - &#x27;0&#x27; + 1) % 10);
+                out.append(shifted);
+            } else {
+                out.append(c);
+            }
+        }
+        System.out.println(out.toString()); // Debe imprimir: JAVA21 tras arreglo
+    }
+}
+</code></pre>
     <div class="buttons">
         <button onclick="location.href='puzzle3.html'">Anterior</button>
         <button onclick="location.href='formulario.html'">Siguiente</button>
     </div>
 </div>
+<script>hljs.highlightAll();</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Agrega bloques de código con resaltado sintáctico de cada puzzle en sus páginas HTML.
- Amplía el contenedor para acomodar el código y aplica estilos oscuros con highlight.js.

## Testing
- `mvn -o -q test` *(falló: Could not transfer artifact maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb4f09a988323b4288d0337f1cc2e