### PR TITLE
Add descriptive hints to puzzle pages

### DIFF
--- a/puzzle1.html
+++ b/puzzle1.html
@@ -56,7 +56,9 @@
 <body>
 <div id="app">
     <h1>Puzzle 1</h1>
-    <p>Aquí se presentará el primer puzzle.</p>
+    <p>Este reto muestra un código que recorre una cadena tomando saltos fijos.
+        Revisa cómo se calculan los límites del bucle y el incremento para
+        evitar errores de índice y extraer sólo las letras que interesan.</p>
     <pre><code class="language-java">package com.chapterescape;
 
 import java.util.List;

--- a/puzzle2.html
+++ b/puzzle2.html
@@ -60,7 +60,9 @@
 <body>
 <div id="app">
     <h1>Puzzle 2</h1>
-    <p>Descripción del segundo puzzle.</p>
+    <p>En este ejercicio dos hilos compiten por recursos bloqueados. Piensa en
+        cómo garantizar que ambos adquieran los candados en un orden coherente
+        para evitar que se queden esperando indefinidamente.</p>
     <pre><code class="language-java">package com.chapterescape;
 
 import java.util.concurrent.locks.Lock;

--- a/puzzle3.html
+++ b/puzzle3.html
@@ -60,7 +60,9 @@
 <body>
 <div id="app">
     <h1>Puzzle 3</h1>
-    <p>Descripción del tercer puzzle.</p>
+    <p>Este desafío trabaja con expresiones regulares para extraer piezas de
+        información. Asegúrate de que la búsqueda apunte sólo al campo deseado
+        y que la captura no incluya texto de más.</p>
     <pre><code class="language-java">package com.chapterescape;
 
 import java.util.List;

--- a/puzzle4.html
+++ b/puzzle4.html
@@ -60,7 +60,9 @@
 <body>
 <div id="app">
     <h1>Puzzle 4</h1>
-    <p>Descripción del cuarto puzzle.</p>
+    <p>La última prueba combina una decodificación Base64 con un desplazamiento
+        de caracteres. Observa el conjunto de caracteres utilizado y la
+        dirección del desplazamiento para reconstruir el mensaje original.</p>
     <pre><code class="language-java">package com.chapterescape;
 
 import java.nio.charset.Charset;


### PR DESCRIPTION
## Summary
- Provide guidance text for each puzzle explaining the concept behind its fix without revealing full solutions

## Testing
- `mvn -q test` *(fails: PluginResolutionException - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb770cd4483239521da9d6fe25562