### PR TITLE
Add back button to puzzle1 page

### DIFF
--- a/puzzle1.html
+++ b/puzzle1.html
@@ -31,6 +31,11 @@
         h1 {
             color: #ff6f61;
         }
+        .buttons {
+            margin-top: 1rem;
+            display: flex;
+            justify-content: space-between;
+        }
         pre {
             text-align: left;
             background: #282c34;
@@ -86,8 +91,11 @@ public class Puzzle1_OffByOne {
         System.out.println(token); // Debe imprimir: VERTX tras arreglo
     }
 }
-</code></pre>
-    <button onclick="location.href='puzzle2.html'">Siguiente</button>
+    </code></pre>
+    <div class="buttons">
+        <button onclick="location.href='bienvenida.html'">Atrás</button>
+        <button onclick="location.href='puzzle2.html'">Siguiente</button>
+    </div>
 </div>
 <script>hljs.highlightAll();</script>
 </body>


### PR DESCRIPTION
## Summary
- Add layout style for navigation buttons on puzzle 1 page
- Introduce back button linking to bienvenida page alongside next button

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aec41a62188323945245de11038b4e