### PR TITLE
Add secondary info box with IntelliJ run note on welcome page

### DIFF
--- a/bienvenida.html
+++ b/bienvenida.html
@@ -12,8 +12,10 @@
             margin: 0;
             min-height: 100vh;
             display: flex;
+            flex-direction: column;
             justify-content: center;
             align-items: center;
+            gap: 2rem;
             background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%);
             color: #333;
         }
@@ -52,12 +54,34 @@
         code {
             font-family: monospace;
         }
+        .info-box {
+            background: #333;
+            color: #fff;
+            padding: 1.5rem;
+            border-radius: 0.75rem;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+            max-width: 400px;
+            width: 100%;
+        }
+        .info-box h2 {
+            color: #ffcc00;
+            margin-top: 0;
+        }
+        .info-box pre {
+            background: #222;
+            color: #ffcc00;
+            padding: 1rem;
+            border-radius: 0.5rem;
+        }
     </style>
 </head>
 <body>
 <div id="app">
     <h1>Escape Room</h1>
     <p>Bienvenido al juego. Resuelve los cuatro puzzles para obtener los tokens y escapar.</p>
+    <button onclick="location.href='puzzle1.html'">Siguiente</button>
+</div>
+<div class="info-box">
     <h2>¿Cómo levantar el servidor?</h2>
     <ol>
         <li>Compila el proyecto:
@@ -70,7 +94,7 @@
     <p>El servicio quedará disponible en <code>http://localhost:8080</code>.</p>
     <p>Si prefieres ejecutar sin empaquetar, usa:</p>
     <pre><code>mvn exec:java -Dexec.mainClass=com.chapterescape.Main</code></pre>
-    <button onclick="location.href='puzzle1.html'">Siguiente</button>
+    <p>También puedes ejecutar el proyecto desde IntelliJ usando el botón <strong>Run</strong>.</p>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Move server startup instructions into a new info box beneath the main welcome card.
- Style the new box differently and mention running the project from IntelliJ via the Run button.

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*


------
https://chatgpt.com/codex/tasks/task_e_68aec525d2348323a7157d2890eddade