### PR TITLE
Add execution guides for puzzle pages

### DIFF
--- a/puzzle1.html
+++ b/puzzle1.html
@@ -56,6 +56,14 @@
         button:hover {
             background: linear-gradient(315deg, #2575fc 0%, #6a11cb 100%);
         }
+        .info-box {
+            margin-top: 1rem;
+            padding: 1rem;
+            background: #e0f7fa;
+            border-left: 5px solid #00796b;
+            border-radius: .5rem;
+            text-align: left;
+        }
     </style>
 </head>
 <body>
@@ -92,6 +100,11 @@ public class Puzzle1_OffByOne {
     }
 }
     </code></pre>
+    <div class="info-box">
+        <h2>Cómo ejecutar</h2>
+        <p>Desde la raíz del proyecto, ejecuta en la terminal:</p>
+        <p><code>mvn exec:java -Dexec.mainClass=com.chapterescape.Puzzle1_OffByOne</code></p>
+    </div>
     <div class="buttons">
         <button onclick="location.href='bienvenida.html'">Atrás</button>
         <button onclick="location.href='puzzle2.html'">Siguiente</button>

--- a/puzzle2.html
+++ b/puzzle2.html
@@ -55,6 +55,14 @@
         button:hover {
             background: linear-gradient(315deg, #2575fc 0%, #6a11cb 100%);
         }
+        .info-box {
+            margin-top: 1rem;
+            padding: 1rem;
+            background: #e0f7fa;
+            border-left: 5px solid #00796b;
+            border-radius: .5rem;
+            text-align: left;
+        }
     </style>
 </head>
 <body>
@@ -122,6 +130,11 @@ public class Puzzle2_Deadlock {
     }
 }
 </code></pre>
+    <div class="info-box">
+        <h2>Cómo ejecutar</h2>
+        <p>Desde la raíz del proyecto, ejecuta en la terminal:</p>
+        <p><code>mvn exec:java -Dexec.mainClass=com.chapterescape.Puzzle2_Deadlock</code></p>
+    </div>
     <div class="buttons">
         <button onclick="location.href='puzzle1.html'">Anterior</button>
         <button onclick="location.href='puzzle3.html'">Siguiente</button>

--- a/puzzle3.html
+++ b/puzzle3.html
@@ -55,6 +55,14 @@
         button:hover {
             background: linear-gradient(315deg, #2575fc 0%, #6a11cb 100%);
         }
+        .info-box {
+            margin-top: 1rem;
+            padding: 1rem;
+            background: #e0f7fa;
+            border-left: 5px solid #00796b;
+            border-radius: .5rem;
+            text-align: left;
+        }
     </style>
 </head>
 <body>
@@ -103,6 +111,11 @@ public class Puzzle3_RegexIntel {
     }
 }
 </code></pre>
+    <div class="info-box">
+        <h2>Cómo ejecutar</h2>
+        <p>Desde la raíz del proyecto, ejecuta en la terminal:</p>
+        <p><code>mvn exec:java -Dexec.mainClass=com.chapterescape.Puzzle3_RegexIntel</code></p>
+    </div>
     <div class="buttons">
         <button onclick="location.href='puzzle2.html'">Anterior</button>
         <button onclick="location.href='puzzle4.html'">Siguiente</button>

--- a/puzzle4.html
+++ b/puzzle4.html
@@ -55,6 +55,14 @@
         button:hover {
             background: linear-gradient(315deg, #2575fc 0%, #6a11cb 100%);
         }
+        .info-box {
+            margin-top: 1rem;
+            padding: 1rem;
+            background: #e0f7fa;
+            border-left: 5px solid #00796b;
+            border-radius: .5rem;
+            text-align: left;
+        }
     </style>
 </head>
 <body>
@@ -101,6 +109,11 @@ public class Puzzle4_CryptoChain {
     }
 }
 </code></pre>
+    <div class="info-box">
+        <h2>Cómo ejecutar</h2>
+        <p>Desde la raíz del proyecto, ejecuta en la terminal:</p>
+        <p><code>mvn exec:java -Dexec.mainClass=com.chapterescape.Puzzle4_CryptoChain</code></p>
+    </div>
     <div class="buttons">
         <button onclick="location.href='puzzle3.html'">Anterior</button>
         <button onclick="location.href='formulario.html'">Siguiente</button>


### PR DESCRIPTION
## Summary
- Add instruction boxes with unique styling across puzzle pages
- Document Maven command to run each puzzle class

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aec562f7b88323b0b5354273a2e429